### PR TITLE
Update rouge highlight theme

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,6 @@ google_analytics:   UA-137799696-2 # out your google-analytics code
 
 # Build settings
 markdown:  kramdown
-highlighter: rouge
 
 kramdown:
   input: GFM

--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,19 @@ github_username:    PARK-JONGSEOK
 google_analytics:   UA-137799696-2 # out your google-analytics code
 
 # Build settings
-markdown:           kramdown
+markdown:  kramdown
+highlighter: rouge
+
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
+  syntax_highlighter_opts:
+    span:
+      line_numbers: false
+    block:  
+      line_numbers: true
+      start_line: 1
+
 paginate:           5
 paginate_path:      "/posts/page:num/"
 plugins:

--- a/_posts/git/2019-10-01-creating-pull-request-template.md
+++ b/_posts/git/2019-10-01-creating-pull-request-template.md
@@ -33,9 +33,9 @@ background: '/img/posts/background/github.png'
 
 - `Pull request`를 할 때마다, 맞춤법 검사를 체크하기 위해서 체크 박스를 템플릿에 추가했습니다.
 
-{% highlight markdown linenos%}
-    -  [ ] 맞춤법 검사
-{% endhighlight %}
+```markdown
+-  [ ] 맞춤법 검사
+```
 
 - 작성 후 하단의 `Commit new file`을 클릭합니다.
 

--- a/_posts/git/2019-10-06-installing-and-updating-git.md
+++ b/_posts/git/2019-10-06-installing-and-updating-git.md
@@ -25,17 +25,16 @@ background: /img/posts/background/git.png
 
 - `GIT`이 설치되어 있을지도 모르니까, 아래의 명령어를 입력하여 확인해봅니다.
 
-{% highlight console linenos%}
-    git --version
-{% endhighlight%}
+```console
+$ git --version
+```
 
 - 만약 설치되어 있지만, 버전이 오래되었다면, 아래의 명령어를 입력하여 `Git` 버전을 업데이트 해줍니다.  
   (2019년 10월 기준으로 `2.23.0`이 최신 버전입니다.)
 
-{% highlight console linenos%}
-    git update-git-for-windows
-{% endhighlight%}
-
+```console
+$ git update-git-for-windows
+```
 
 ![installing-and-updating-git-1](/img/posts/git/installing-and-updating-git-1.png)
 

--- a/_posts/languages/ruby/2019-10-04-installing-ruby.md
+++ b/_posts/languages/ruby/2019-10-04-installing-ruby.md
@@ -66,9 +66,9 @@ background: '/img/posts/background/ruby.png'
 
 - `MSY32` 설치가 끝난 후, 터미널을 실행 시켜 잘 설치되었는지 확인해봅니다.
 
-{% highlight console linenos%}
-    ruby -v
-{% endhighlight %}
+```console
+$ ruby -v
+```
 
 ![installing-ruby-6](/img/posts/languages/ruby/installing-ruby-6.png)
 

--- a/assets/vendor/startbootstrap-clean-blog/scss/clean-blog.scss
+++ b/assets/vendor/startbootstrap-clean-blog/scss/clean-blog.scss
@@ -7,3 +7,4 @@
 @import "contact.scss";
 @import "footer.scss";
 @import "bootstrap-overrides.scss";
+@import "syntax.scss";

--- a/assets/vendor/startbootstrap-clean-blog/scss/syntax.scss
+++ b/assets/vendor/startbootstrap-clean-blog/scss/syntax.scss
@@ -1,0 +1,209 @@
+.highlight table td { padding: 5px; }
+.highlight table pre { margin: 0; }
+.highlight .cm {
+  color: #999988;
+  font-style: italic;
+}
+.highlight .cp {
+  color: #999999;
+  font-weight: bold;
+}
+.highlight .c1 {
+  color: #999988;
+  font-style: italic;
+}
+.highlight .cs {
+  color: #999999;
+  font-weight: bold;
+  font-style: italic;
+}
+.highlight .c, .highlight .ch, .highlight .cd, .highlight .cpf {
+  color: #999988;
+  font-style: italic;
+}
+.highlight .err {
+  color: #a61717;
+  background-color: #e3d2d2;
+}
+.highlight .gd {
+  color: #000000;
+  background-color: #ffdddd;
+}
+.highlight .ge {
+  color: #000000;
+  font-style: italic;
+}
+.highlight .gr {
+  color: #aa0000;
+}
+.highlight .gh {
+  color: #999999;
+}
+.highlight .gi {
+  color: #000000;
+  background-color: #ddffdd;
+}
+.highlight .go {
+  color: #888888;
+}
+.highlight .gp {
+  color: #555555;
+}
+.highlight .gs {
+  font-weight: bold;
+}
+.highlight .gu {
+  color: #aaaaaa;
+}
+.highlight .gt {
+  color: #aa0000;
+}
+.highlight .kc {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kd {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kn {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kp {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kr {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kt {
+  color: #445588;
+  font-weight: bold;
+}
+.highlight .k, .highlight .kv {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .mf {
+  color: #009999;
+}
+.highlight .mh {
+  color: #009999;
+}
+.highlight .il {
+  color: #009999;
+}
+.highlight .mi {
+  color: #009999;
+}
+.highlight .mo {
+  color: #009999;
+}
+.highlight .m, .highlight .mb, .highlight .mx {
+  color: #009999;
+}
+.highlight .sb {
+  color: #d14;
+}
+.highlight .sc {
+  color: #d14;
+}
+.highlight .sd {
+  color: #d14;
+}
+.highlight .s2 {
+  color: #d14;
+}
+.highlight .se {
+  color: #d14;
+}
+.highlight .sh {
+  color: #d14;
+}
+.highlight .si {
+  color: #d14;
+}
+.highlight .sx {
+  color: #d14;
+}
+.highlight .sr {
+  color: #009926;
+}
+.highlight .s1 {
+  color: #d14;
+}
+.highlight .ss {
+  color: #990073;
+}
+.highlight .s, .highlight .sa, .highlight .dl {
+  color: #d14;
+}
+.highlight .na {
+  color: #008080;
+}
+.highlight .bp {
+  color: #999999;
+}
+.highlight .nb {
+  color: #0086B3;
+}
+.highlight .nc {
+  color: #445588;
+  font-weight: bold;
+}
+.highlight .no {
+  color: #008080;
+}
+.highlight .nd {
+  color: #3c5d5d;
+  font-weight: bold;
+}
+.highlight .ni {
+  color: #800080;
+}
+.highlight .ne {
+  color: #990000;
+  font-weight: bold;
+}
+.highlight .nf, .highlight .fm {
+  color: #990000;
+  font-weight: bold;
+}
+.highlight .nl {
+  color: #990000;
+  font-weight: bold;
+}
+.highlight .nn {
+  color: #555555;
+}
+.highlight .nt {
+  color: #000080;
+}
+.highlight .vc {
+  color: #008080;
+}
+.highlight .vg {
+  color: #008080;
+}
+.highlight .vi {
+  color: #008080;
+}
+.highlight .nv, .highlight .vm {
+  color: #008080;
+}
+.highlight .ow {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .o {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .w {
+  color: #bbbbbb;
+}
+.highlight {
+  background-color: #f8f8f8;
+}


### PR DESCRIPTION
Closes #15  

## Summary

- `rougify help style`을 입력하면, `rouge`에서 사용할 수 있는 테마를 보여줌
```console
$ rougify style base16.monokai.light > assets/vendor/startbootstrap-clean-blog/scss/syntax.css
```
- 위의 명령어를 입력하여, 테마를 변경할 수 있다.
- 코드를 사용할 때는 앞에 탭을 생략한다.